### PR TITLE
Remove gnome.name

### DIFF
--- a/action_manager.py
+++ b/action_manager.py
@@ -33,26 +33,26 @@ class ActionManager:
     def check_fight_option(self, gnome_first, gnome_second):
         gnome_first_action = gnome_first.strategy[gnome_first.event_counter]
         gnome_second_action = gnome_second.strategy[gnome_second.event_counter]
-        encounter = f"{gnome_first.name} used {gnome_first_action} and {gnome_second.name} used {gnome_second_action}"
+        encounter = f"{gnome_first.user} used {gnome_first_action} and {gnome_second.user} used {gnome_second_action}"
         fight_message_dict = {
                     "encounter": encounter,
                     "outcome": ""
                 }
         match (gnome_first_action, gnome_second_action):
             case ("rock", "paper") | ("paper", "scissor") | ("scissor", "rock"):
-                print(f"{gnome_second.name} won")
+                print(f"{gnome_second.user} won")
                 gnome_second.actual_points += 1
                 gnome_second.kill_count += 1
                 gnome_first.actual_points -= 1
-                outcome = f"{gnome_second.name} won"
+                outcome = f"{gnome_second.user} won"
                 fight_message_dict["outcome"] = outcome
                 return fight_message_dict
             case ("rock", "scissor") | ("paper", "rock") | ("scissor", "paper"):
-                print(f"{gnome_first.name} won")
+                print(f"{gnome_first.user} won")
                 gnome_first.actual_points += 1
                 gnome_first.kill_count += 1
                 gnome_second.actual_points -= 1
-                outcome = f"{gnome_first.name} won"
+                outcome = f"{gnome_first.user} won"
                 fight_message_dict["outcome"] = outcome
                 return fight_message_dict
             case _:

--- a/action_manager_test.py
+++ b/action_manager_test.py
@@ -12,9 +12,9 @@ class TestActionManager(unittest.TestCase):
  
 
         # creating 3 gnomes
-        self.gnome1 = Gnome("gnome1", "user1")
-        self.gnome2 = Gnome("gnome2", "user2")
-        self.gnome3 = Gnome("gnome3", "user3")
+        self.gnome1 = Gnome("user1")
+        self.gnome2 = Gnome("user2")
+        self.gnome3 = Gnome("user3")
 
  
 

--- a/gnome.py
+++ b/gnome.py
@@ -2,8 +2,7 @@ import random
 
 
 class Gnome:
-    def __init__(self, name, user) -> None:
-        self.name = name
+    def __init__(self, user) -> None:
         self.user = user
         self.location = {}
         self.strategy = []
@@ -121,7 +120,7 @@ class Map:
 if __name__ == "__main__":
     gnomes_list = []
     for n in range (10):
-        gnome = Gnome(f"lol{n}", f"loluser{n}")
+        gnome = Gnome(f"loluser{n}")
         gnomes_list.append(gnome)
 
     map = Map(19, 19, 5)


### PR DESCRIPTION
changed .name into .user. Gnomes do not have separate name, only use users' name.